### PR TITLE
Feature SSM definitions

### DIFF
--- a/DTDL/ssm_sink.json
+++ b/DTDL/ssm_sink.json
@@ -34,14 +34,14 @@
                     "enumValue": "NONE"
                 },
                 {
-                    "name": "NB-IoT",
+                    "name": "NBIoT",
                     "displayName": "NB-IoT",
-                    "enumValue": "NB_IoT"
+                    "enumValue": "NBIoT"
                 },
                 {
-                    "name": "CAT-M",
+                    "name": "CATM",
                     "displayName": "CAT-M",
-                    "enumValue": "CAT_M"
+                    "enumValue": "CATM"
                 },
                 {
                     "name": "LTE",

--- a/DTDL/ssm_sink.json
+++ b/DTDL/ssm_sink.json
@@ -1,0 +1,66 @@
+{
+    "@context": "dtmi:dtdl:context;2",
+    "@id": "dtmi:io:tributech:sink:ssm;1",
+    "extends": "dtmi:io:tributech:sink:base;1",
+    "@type": "Interface",
+    "displayName": "Sensor Security Module Sink",
+    "contents": [ 
+      {
+        "@type": "Property",
+        "name": "ProofsEndpoint",
+        "schema": "string",
+        "writable": true,
+        "displayName": "Proofs Endpoint",
+        "description": "Endpoint-URI for the submission of the proofs. E.g. <dsk-node-subdomain>.dataspace-node.com. REMARK: Appropriate TLS-certificates needs to be in place."
+      },
+      {
+        "@type": "Property",
+        "name": "RawValuesEndpoint",
+        "schema": "string",
+        "writable": true,
+        "displayName": "Values Endpoint",
+        "description": "Endpoint-URI for the submission of the raw-values. E.g. <dsk-node-subdomain>.dataspace-node.com. REMARK: Appropriate TLS-certificates needs to be in place."
+      },
+      {
+        "@type": "Property",
+        "name": "ConnectivityTechnology",
+        "schema": {
+            "@type": "Enum",
+            "valueSchema": "string",
+            "enumValues": [
+                {
+                    "name": "None",
+                    "displayName": "None",
+                    "enumValue": "NONE"
+                },
+                {
+                    "name": "NB-IoT",
+                    "displayName": "NB-IoT",
+                    "enumValue": "NB_IoT"
+                },
+                {
+                    "name": "CAT-M",
+                    "displayName": "CAT-M",
+                    "enumValue": "CAT_M"
+                },
+                {
+                    "name": "LTE",
+                    "displayName": "LTE",
+                    "enumValue": "LTE"
+                }
+            ]
+        },
+        "writable": true,
+        "displayName": "Connectivity Technology",
+        "description": "Cellular connectivity technology used to submit proofs and values."
+      },
+      {
+        "@type": "Property",
+        "name": "APN",
+        "schema": "string",
+        "writable": true,
+        "displayName": "Access Point Name",
+        "description": "Access Point Name for the cellular connectivity."
+      }
+    ]
+  }

--- a/DTDL/ssm_source_air_quality.json
+++ b/DTDL/ssm_source_air_quality.json
@@ -1,0 +1,18 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:io:tributech:source:airquality;1",
+  "@type": "Interface",
+  "extends": "dtmi:io:tributech:source:base;1",
+  "displayName": "Air Quality Source",
+  "contents": [
+    {
+      "@type": "Relationship",
+      "name": "Streams",
+      "minMultiplicity": 0,
+      "maxMultiplicity": 3,
+      "target": "dtmi:io:tributech:stream:airquality;1",
+      "displayName": "Streams",
+      "description": "Contains all streams the given source."
+    }
+  ]
+}

--- a/DTDL/ssm_source_deviceinterfaceprotocol.json
+++ b/DTDL/ssm_source_deviceinterfaceprotocol.json
@@ -1,16 +1,16 @@
 {
   "@context": "dtmi:dtdl:context;2",
-  "@id": "dtmi:io:tributech:source:airquality;1",
+  "@id": "dtmi:io:tributech:source:deviceinterfaceprotocol;1",
   "@type": "Interface",
   "extends": "dtmi:io:tributech:source:base;1",
-  "displayName": "Air Quality Source",
+  "displayName": "Device Interface Protocol",
   "contents": [
     {
       "@type": "Relationship",
       "name": "Streams",
       "minMultiplicity": 0,
-      "maxMultiplicity": 3,
-      "target": "dtmi:io:tributech:stream:airquality;1",
+      "maxMultiplicity": 10,
+      "target": "dtmi:io:tributech:stream:deviceinterfaceprotocol;1",
       "displayName": "Streams",
       "description": "Contains all streams of the given source."
     }

--- a/DTDL/ssm_source_modbus.json
+++ b/DTDL/ssm_source_modbus.json
@@ -1,0 +1,94 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:io:tributech:source:modbus;1",
+  "@type": "Interface",
+  "extends": "dtmi:io:tributech:source:base;1",
+  "displayName": "Modbus Source",
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "UnitId",
+      "schema": "integer",
+      "writable": true,
+      "displayName": "Unit Id",
+      "description": "Unit Id in terms of Modbus RTU."
+    },
+    {
+      "@type": "Property",
+      "name": "MsbFirst",
+      "schema": "boolean",
+      "writable": true,
+      "displayName": "Most significant byte first",
+      "description": "Specifies the byte order."
+    },
+    {
+      "@type": "Property",
+      "name": "MswFirst",
+      "schema": "boolean",
+      "writable": true,
+      "displayName": "Most significant word first",
+      "description": "Specifies the word-order."
+    },
+    {
+      "@type": "Property",
+      "name": "Baudrate",
+      "schema": "integer",
+      "writable": true,
+      "displayName": "Baud rate",
+      "description": "Specifies the baud rate which in use for the underlying serial connection for the Modbus RTU connection."
+    },
+    {
+      "@type": "Property",
+      "name": "DataBits",
+      "schema": "integer",
+      "writable": true,
+      "displayName": "Data bits",
+      "description": "Specifies the amount of data bits which are in use for the underlying serial connection for the Modbus RTU connection."
+    },
+    {
+      "@type": "Property",
+      "name": "StopBits",
+      "schema": "integer",
+      "writable": true,
+      "displayName": "Stop bits",
+      "description": "Specifies the amount of stop bits which are in use for the underlying serial connection for the Modbus RTU connection."
+    },
+    {
+      "@type": "Property",
+      "name": "Parity",
+      "schema": {
+        "@type": "Enum",
+        "valueSchema": "string",
+        "enumValues": [
+            {
+                "name": "none",
+                "displayName": "none",
+                "enumValue": "none"
+            },
+            {
+                "name": "odd",
+                "displayName": "odd",
+                "enumValue": "odd"
+            },
+            {
+                "name": "even",
+                "displayName": "even",
+                "enumValue": "even"
+            }
+        ]
+      },
+      "writable": true,
+      "displayName": "Parity",
+      "description": "Specifies the parity which are in use for the underlying serial connection for the Modbus RTU connection."
+    }
+    {
+      "@type": "Relationship",
+      "name": "Streams",
+      "minMultiplicity": 0,
+      "maxMultiplicity": 25,
+      "target": "dtmi:io:tributech:stream:modbus;1",
+      "displayName": "Streams",
+      "description": "Contains all streams of the given source."
+    }
+  ]
+}

--- a/DTDL/ssm_source_modbus.json
+++ b/DTDL/ssm_source_modbus.json
@@ -61,19 +61,19 @@
         "valueSchema": "string",
         "enumValues": [
             {
-                "name": "none",
-                "displayName": "none",
-                "enumValue": "none"
+                "name": "None",
+                "displayName": "None",
+                "enumValue": "NONE"
             },
             {
-                "name": "odd",
-                "displayName": "odd",
-                "enumValue": "odd"
+                "name": "Odd",
+                "displayName": "Odd",
+                "enumValue": "ODD"
             },
             {
-                "name": "even",
-                "displayName": "even",
-                "enumValue": "even"
+                "name": "Even",
+                "displayName": "Even",
+                "enumValue": "EVEN"
             }
         ]
       },

--- a/DTDL/ssm_source_modbus.json
+++ b/DTDL/ssm_source_modbus.json
@@ -35,7 +35,7 @@
       "schema": "integer",
       "writable": true,
       "displayName": "Baud rate",
-      "description": "Specifies the baud rate which in use for the underlying serial connection for the Modbus RTU connection."
+      "description": "Specifies the baud rate which is used for the underlying serial connection for the Modbus RTU connection."
     },
     {
       "@type": "Property",

--- a/DTDL/ssm_source_modbus.json
+++ b/DTDL/ssm_source_modbus.json
@@ -51,7 +51,7 @@
       "schema": "integer",
       "writable": true,
       "displayName": "Stop bits",
-      "description": "Specifies the amount of stop bits which are in use for the underlying serial connection for the Modbus RTU connection."
+      "description": "Specifies the amount of stop bits which are used for the underlying serial connection for the Modbus RTU connection."
     },
     {
       "@type": "Property",

--- a/DTDL/ssm_source_xmc.json
+++ b/DTDL/ssm_source_xmc.json
@@ -1,18 +1,18 @@
 {
   "@context": "dtmi:dtdl:context;2",
-  "@id": "dtmi:io:tributech:source:airquality;1",
+  "@id": "dtmi:io:tributech:source:xmc;1",
   "@type": "Interface",
   "extends": "dtmi:io:tributech:source:base;1",
-  "displayName": "Air Quality Source",
+  "displayName": "XMC Source",
   "contents": [
     {
       "@type": "Relationship",
       "name": "Streams",
       "minMultiplicity": 0,
-      "maxMultiplicity": 3,
-      "target": "dtmi:io:tributech:stream:airquality;1",
+      "maxMultiplicity": 2,
+      "target": "dtmi:io:tributech:stream:xmc;1",
       "displayName": "Streams",
-      "description": "Contains all streams of the given source."
+      "description": "Contains all streams the given source."
     }
   ]
 }

--- a/DTDL/ssm_stream_air_quality.json
+++ b/DTDL/ssm_stream_air_quality.json
@@ -1,0 +1,42 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:io:tributech:stream:airquality;1",
+  "@type": "Interface",
+  "extends": "dtmi:io:tributech:stream:base;1",
+  "displayName": "Air Quality Stream",
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "Measure",
+      "schema": {
+        "@type": "Enum",
+        "valueSchema": "string",
+        "enumValues": [
+            {
+                "name": "CO2",
+                "displayName": "CO2",
+                "enumValue": "CO2"
+            },
+            {
+                "name": "Temperature",
+                "displayName": "Temperature",
+                "enumValue": "Temperature"
+            },
+            {
+                "name": "VOC",
+                "displayName": "VOC",
+                "enumValue": "VOC"
+            },
+            {
+                "name": "Humidity",
+                "displayName": "Humidity",
+                "enumValue": "Humidity"
+            }
+        ]
+      },
+      "writable": false,
+      "displayName": "Measure",
+      "description": "Specifies the kind of a measure of a stream of the Air Quality module."
+    }
+  ]
+}

--- a/DTDL/ssm_stream_air_quality.json
+++ b/DTDL/ssm_stream_air_quality.json
@@ -34,7 +34,7 @@
             }
         ]
       },
-      "writable": false,
+      "writable": true,
       "displayName": "Measure",
       "description": "Specifies the kind of a measure of a stream of the Air Quality module."
     }

--- a/DTDL/ssm_stream_deviceinterfaceprotocol.json
+++ b/DTDL/ssm_stream_deviceinterfaceprotocol.json
@@ -1,0 +1,18 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:io:tributech:stream:deviceinterfaceprotocol;1",
+  "@type": "Interface",
+  "extends": "dtmi:io:tributech:stream:base;1",
+  "displayName": "Device Interface Protocol Stream",
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "MinInterval",
+      "schema": "duration",
+      "writable": true,
+      "displayName": "Minimum Time Interval",
+      "description": "Specifies the minimal time-interval of values which can be provided for this stream.",
+      "comment": "Data for the stream provided in less than the specified minimal time-interval gets discarded."
+    }
+  ]
+}

--- a/DTDL/ssm_stream_modbus.json
+++ b/DTDL/ssm_stream_modbus.json
@@ -30,28 +30,28 @@
         "valueSchema": "string",
         "enumValues": [
             {
-                "name": "UINT16",
-                "displayName": "UINT16",
+                "name": "Uint16",
+                "displayName": "Uint16",
                 "enumValue": "UINT16"
             },
             {
-                "name": "UINT32",
-                "displayName": "UINT32",
+                "name": "Uint32",
+                "displayName": "Uint32",
                 "enumValue": "UINT32"
             },
             {
-              "name": "INT16",
-              "displayName": "INT16",
+              "name": "Int16",
+              "displayName": "Int16",
               "enumValue": "INT16"
             },
             {
-                "name": "INT32",
-                "displayName": "INT32",
+                "name": "Int32",
+                "displayName": "Int32",
                 "enumValue": "INT32"
             },
             {
-                "name": "FLOAT",
-                "displayName": "FLOAT",
+                "name": "Float",
+                "displayName": "Float",
                 "enumValue": "FLOAT"
             }
         ]

--- a/DTDL/ssm_stream_modbus.json
+++ b/DTDL/ssm_stream_modbus.json
@@ -1,0 +1,72 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:io:tributech:stream:modbus;1",
+  "@type": "Interface",
+  "extends": "dtmi:io:tributech:stream:base;1",
+  "displayName": "Modbus Stream",
+  "description": "Represents a modbus register.",
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "RegisterAddress",
+      "schema": "integer",
+      "writable": true,
+      "displayName": "Register address",
+      "description": "Specifies the register address in the terminology of modbus RTU which gets used in order to read the register."
+    },
+    {
+      "@type": "Property",
+      "name": "FunctionCode",
+      "schema": "integer",
+      "writable": true,
+      "displayName": "Function Code",
+      "description": "Specifies the function code in the terminology of modbus RTU which gets used in order to read the register."
+    },
+    {
+      "@type": "Property",
+      "name": "DataType",
+      "schema": {
+        "@type": "Enum",
+        "valueSchema": "string",
+        "enumValues": [
+            {
+                "name": "UINT16",
+                "displayName": "UINT16",
+                "enumValue": "UINT16"
+            },
+            {
+                "name": "UINT32",
+                "displayName": "UINT32",
+                "enumValue": "UINT32"
+            },
+            {
+              "name": "INT16",
+              "displayName": "INT16",
+              "enumValue": "INT16"
+            },
+            {
+                "name": "INT32",
+                "displayName": "INT32",
+                "enumValue": "INT32"
+            },
+            {
+                "name": "FLOAT",
+                "displayName": "FLOAT",
+                "enumValue": "FLOAT"
+            }
+        ]
+      },
+      "writable": true,
+      "displayName": "Data type",
+      "description": "Specifies the data type of the modbus register."
+    },
+    {
+      "@type": "Property",
+      "name": "Factor",
+      "schema": "float",
+      "writable": true,
+      "displayName": "Factor",
+      "description": "Specifies a factor. It can be used to scale a certain register value to handle it more easily. Can be set to 1 to get the raw value of the register."
+    }
+  ]
+}

--- a/DTDL/ssm_stream_xmc.json
+++ b/DTDL/ssm_stream_xmc.json
@@ -1,0 +1,32 @@
+{
+  "@context": "dtmi:dtdl:context;2",
+  "@id": "dtmi:io:tributech:stream:xmc;1",
+  "@type": "Interface",
+  "extends": "dtmi:io:tributech:stream:base;1",
+  "displayName": "XMC Stream",
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "Measure",
+      "schema": {
+        "@type": "Enum",
+        "valueSchema": "string",
+        "enumValues": [
+            {
+                "name": "Temperature",
+                "displayName": "Temperature",
+                "enumValue": "Temperature"
+            },
+            {
+                "name": "AnalogInput",
+                "displayName": "Analog Input",
+                "enumValue": "AnalogInput"
+            }
+        ]
+      },
+      "writable": false,
+      "displayName": "Measure",
+      "description": "Specifies the kind of a measure of a stream of the XMC."
+    }
+  ]
+}


### PR DESCRIPTION
The following "SetConfiguration" example request-paylod has been used in order to establish the mapping between native SSM-request and DTDL-definition.

```
{
  "TransactionNr": 13,                      // Can be set to fixed or random integer. It's used to correlate request and response.
  "Operation": "SetConfiguration",          // Must be "SetConfiguration"
  "SubmitProofs": true,                     // dtmi:io:tributech:device:ssm;1 -> SubmitProofs
  "SubmitRawValues": true,                  // dtmi:io:tributech:device:ssm;1 -> SubmitRawValues
  "Endpoints": {
    "Proofs": "demo-node-a.dataspace-node.com",             // dtmi:io:tributech:sink:ssm;1 -> ProofsEndpoint
    "RawValues": "demo-node-a.dataspace-node.com"           // dtmi:io:tributech:sink:ssm;1 -> RawValuesEndpoint
  },
  "Connectivity": {
    "Technology": "NB-IoT",                                 // dtmi:io:tributech:sink:ssm;1 -> ConnectivityTechnology
    "Apn": "nb-iot.t-mobile.at"                             // dtmi:io:tributech:sink:ssm;1 -> APN
  },
  "Sources": [
    {                                                       // JSON-object added if dtmi:io:tributech:device:base;1 -> Sources contains one instance of dtmi:io:tributech:source:airquality;1
      "Name": "Air Quality",                                // Must be "Air Quality"
      "Interface": "dtmi:io:tributech:source:airquality;1",                             // Must be "dtmi:io:tributech:source:airquality;1"
      "Streams": 
      [
        {                                                               
          "ValueMetaDataId": "088900c1-8008-7108-0300-000000000000",    // dtmi:io:tributech:stream:base;1 -> ValueMetadataId
          "Name": "CO2",                                                // dtmi:io:tributech:stream:airquality;1 -> Measure
          "Unit": "ppm",                                                // Mapping based on dtmi:io:tributech:stream:airquality;1 -> Measure ("CO2" to "ppm", "Temp" to "°C", "Humidity" to "%", "VOC" to "ppm")
          "Cycle": 10000,                                               // dtmi:io:tributech:stream:base;1 -> SubmissionInterval
          "MerkleTreeMaxDepth": 4,                                      // dtmi:io:tributech:stream:base;1 -> MerkleTreeDepth
          "MerkleTreeTimeout": 100                                      // dtmi:io:tributech:stream:base;1 -> MerkleTreeTimeout
        }
      ]
    },
    {                                                       // JSON-object added if dtmi:io:tributech:device:base;1 -> Sources contains one instance of dtmi:io:tributech:source:xmc;1
      "Name": "CPU",                                        // Must be "CPU"
      "Interface": "dtmi:io:tributech:source:xmc;1",                                   // Must be "dtmi:io:tributech:source:xmc;1"
      "Streams":
      [
        {
          "ValueMetaDataId": "088900c1-8008-7108-0500-000000000000",    // dtmi:io:tributech:stream:base;1 -> ValueMetadataId
          "Name": "Temperature",                                        // dtmi:io:tributech:stream:xmc;1 -> Measure
          "Unit": "Celsius",                                            // Mapping based on dtmi:io:tributech:stream:xmc;1 -> Measure ("Temperature" to "Celsius", "Analog Input" to "mA")
          "Cycle": 10000,                                               // dtmi:io:tributech:stream:base;1 -> SubmissionInterval
          "MerkleTreeMaxDepth": 4,                                      // dtmi:io:tributech:stream:base;1 -> MerkleTreeDepth
          "MerkleTreeTimeout": 100                                      // dtmi:io:tributech:stream:base;1 -> MerkleTreeTimeout
        },
        {
          "ValueMetaDataId": "088900c1-8008-7108-0600-000000000000",    // dtmi:io:tributech:stream:base;1 -> ValueMetadataId
          "Name": "Analog Input",                                       // dtmi:io:tributech:stream:xmc;1 -> Measure
          "Unit": "mA",                                                 // Mapping based on dtmi:io:tributech:stream:xmc;1 -> Measure ("Temperature" to "Celsius", "Analog Input" to "mA")
          "Cycle": 10000,                                               // dtmi:io:tributech:stream:base;1 -> SubmissionInterval
          "MerkleTreeMaxDepth": 4,                                      // dtmi:io:tributech:stream:base;1 -> MerkleTreeDepth
          "MerkleTreeTimeout": 100                                      // dtmi:io:tributech:stream:base;1 -> MerkleTreeTimeout
        }
      ]
    },
    {                                                       // JSON-object added if dtmi:io:tributech:device:base;1 -> Sources contains instance one instance of dtmi:io:tributech:source:deviceinterfaceprotocol;1
      "Name": "Provide Values",                             // Must be "Provide Values"    
      "Interface": "dtmi:io:tributech:source:deviceinterfaceprotocol;1",               // Must be "dtmi:io:tributech:source:deviceinterfaceprotocol;1"
      "Streams":
      [
        {
          "ValueMetaDataId": "10101010-2020-3030-4040-505050505051",    // dtmi:io:tributech:stream:base;1 -> ValueMetadataId
          "Name": "External Sensor 1",                                  // dtmi:io:tributech:stream:base;1 -> Name
          "Unit": "ppm",                                                // dtmi:io:tributech:stream:base;1 -> Unit
          "MinInterval": 10000,                                         // dtmi:io:tributech:stream:deviceinterfaceprotocol;1 -> MinInterval
          "MerkleTreeMaxDepth": 4,                                      // dtmi:io:tributech:stream:base;1 -> MerkleTreeDepth
          "MerkleTreeTimeout": 100                                      // dtmi:io:tributech:stream:base;1 -> MerkleTreeTimeout
        },
        {
          "ValueMetaDataId": "10101010-2020-3030-4040-505050505052",    // dtmi:io:tributech:stream:base;1 -> ValueMetadataId
          "Name": "External Sensor 2",                                  // dtmi:io:tributech:stream:base;1 -> Name
          "Unit": "ppm",                                                // dtmi:io:tributech:stream:base;1 -> Unit
          "MinInterval": 10000,                                         // dtmi:io:tributech:stream:deviceinterfaceprotocol;1 -> MinInterval
          "MerkleTreeMaxDepth": 4,                                      // dtmi:io:tributech:stream:base;1 -> MerkleTreeDepth
          "MerkleTreeTimeout": 100                                      // dtmi:io:tributech:stream:base;1 -> MerkleTreeTimeout
        }
      ]
    },
    {                                                                   // JSON-object added if dtmi:io:tributech:device:base;1 -> Sources contains one instance of dtmi:io:tributech:source:modbus;1
      "Name": "Energymeter ABB 1",                                      // dtmi:io:tributech:source:base;1 -> Name
      "Interface": "dtmi:io:tributech:source:modbus;1",                                            // Must be "dtmi:io:tributech:source:modbus;1"
      "UnitId": 1,                                                      // dtmi:io:tributech:source:modbus;1 -> UnitId
      "MsbFirst": true,                                                 // dtmi:io:tributech:source:modbus;1 -> MsbFirst
      "MswFirst": true,                                                 // dtmi:io:tributech:source:modbus;1 -> MswFirst
      "SerialConfig":                                             
      {
        "Baudrate": 115200,                                             // dtmi:io:tributech:source:modbus;1 -> Baudrate
        "DataBits": 8,                                                  // dtmi:io:tributech:source:modbus;1 -> DataBits
        "StopBits": 1,                                                  // dtmi:io:tributech:source:modbus;1 -> StopBits
        "Parity": "none"                                                // dtmi:io:tributech:source:modbus;1 -> Parity
      },
      "Streams":
      [
        {
          "ValueMetaDataId": "088900c1-8008-7108-0600-000000000000",    // dtmi:io:tributech:stream:base;1 -> ValueMetadataId
          "Name": "Voltage",                                            // dtmi:io:tributech:stream:base;1 -> Name
          "Unit": "Volt",                                               // dtmi:io:tributech:stream:base;1 -> Unit
          "RegisterAddress": 100,                                       // dtmi:io:tributech:stream:modbus;1 -> RegisterAddress
          "FunctionCode": 3,                                            // dtmi:io:tributech:stream:modbus;1 -> FunctionCode
          "Datatype": "UINT16",                                         // dtmi:io:tributech:stream:modbus;1 -> DataType
          "Factor": 0.01,                                               // dtmi:io:tributech:stream:modbus;1 -> Factor
          "Cycle": 10000,                                               // dtmi:io:tributech:stream:base;1 -> SubmissionInterval
          "MerkleTreeMaxDepth": 4,                                      // dtmi:io:tributech:stream:base;1 -> MerkleTreeDepth
          "MerkleTreeTimeout": 100                                      // dtmi:io:tributech:stream:base;1 -> MerkleTreeTimeout
        },
        {
          "ValueMetaDataId": "088900c1-8008-7108-1400-000000000000",    // dtmi:io:tributech:stream:base;1 -> ValueMetadataId
          "Name": "Frequency",                                          // dtmi:io:tributech:stream:base;1 -> Name
          "Unit": "Hz",                                                 // dtmi:io:tributech:stream:base;1 -> Unit
          "RegisterAddress": 100,                                       // dtmi:io:tributech:stream:modbus;1 -> RegisterAddress
          "FunctionCode": 3,                                            // dtmi:io:tributech:stream:modbus;1 -> FunctionCode
          "Datatype": "UINT16",                                         // dtmi:io:tributech:stream:modbus;1 -> DataType
          "Factor": 0.01,                                               // dtmi:io:tributech:stream:modbus;1 -> Factor
          "Cycle": 10000,                                               // dtmi:io:tributech:stream:base;1 -> SubmissionInterval
          "MerkleTreeMaxDepth": 4,                                      // dtmi:io:tributech:stream:base;1 -> MerkleTreeDepth
          "MerkleTreeTimeout": 100                                      // dtmi:io:tributech:stream:base;1 -> MerkleTreeTimeout
        }
      ]
    },
    {                                   
      "Name": "Energymeter ABB 2",                                      // see above
      "Interface": "dtmi:io:tributech:source:modbus;1",                                            
      "UnitId": 2,
      "MsbFirst": false,
      "MswFirst": true,
      "Streams":
      [
        {
          "ValueMetaDataId": "088900c1-8008-7108-0600-000000000001",
          "Name": "Voltage",
          "Unit": "Volt",
          "RegisterAddress": 100,
          "FunctionCode": 3,
          "Datatype": "UINT16",
          "Factor": 0.01,
          "Cycle": 10000,
          "MerkleTreeMaxDepth": 4,
          "MerkleTreeTimeout": 100
        }
      ]
    }
  ]
}
```