### PR TITLE
fix: duration type

### DIFF
--- a/DTDL/base_sink.json
+++ b/DTDL/base_sink.json
@@ -10,7 +10,7 @@
       "schema": "integer",
       "writable": true,
       "displayName": "Max batch size",
-      "description": "The maximum number of values to send as batch in one message to the sink."
+      "description": "The maximum number of values to send as batch in one message to the sink (e.g. 20 (ProofSink), 1024 (ValueSink))."
     },
     {
       "@type": "Property",
@@ -18,7 +18,7 @@
       "schema": "integer",
       "writable": true,
       "displayName": "Flush interval",
-      "description": "The interval in which the values should be flushed from the buffer and send to the API. Regardless if the MaxBatchSize was reached."
+      "description": "The interval in which the values should be flushed from the buffer and send to the API. Regardless if the MaxBatchSize was reached. e.g. 1s"
     }
   ]
 }

--- a/DTDL/base_sink.json
+++ b/DTDL/base_sink.json
@@ -18,7 +18,7 @@
       "schema": "integer",
       "writable": true,
       "displayName": "Flush interval",
-      "description": "The interval in which the values should be flushed from the buffer and send to the API. Regardless if the MaxBatchSize was reached. e.g. 1s"
+      "description": "The interval (in seconds) in which the values should be flushed from the buffer and send to the API. Regardless if the MaxBatchSize was reached. e.g. 1"
     }
   ]
 }

--- a/DTDL/base_stream.json
+++ b/DTDL/base_stream.json
@@ -18,7 +18,7 @@
       "schema": "string",
       "writable": true,
       "displayName": "ValueMetadataId",
-      "description": "Represents the global unique id of a stream."
+      "description": "Represents the global unique id (UUID) of a stream."
     },
     {
       "@type": "Property",
@@ -41,27 +41,26 @@
       "name": "MerkleTreeDepth",
       "schema": "integer",
       "writable": true,
-      "displayName": "Merkle Tree Depth",
-      "description": "Depth of the binary merkle-tree used for proof generation. Value used as 2^MerkleTreeDepth.",
-      "comment": "Proofs allows to verify integrity and origin of the stream. A proof represents a binary-merkle-tree and 2^MerkleTreeDepth values are necessary to build a single proof."
+      "displayName": "Max Merkle Tree Depth",
+      "description": "Maximum depth of the binary merkle tree used for proof generation (e.g. 12). Value used as 2^MerkleTreeDepth.",
+      "comment": "Proofs allows to verify integrity and origin of the stream. A proof represents a binary-merkle tree and 2^MerkleTreeDepth values are necessary to build a single proof."
     },
     {
       "@type": "Property",
       "name": "MerkleTreeTimeout",
-      "schema": "duration",
+      "schema": "integer",
       "writable": true,
-      "displayName": "Merkle Tree Timeout",
-      "description": "Timeout for a single merkle-tree for proofs in ms.",
-      "comment": "If a stream doesn't provides enought values to build an entire merkle tree with the given depth in the given period it will be splitted into smaller merkle-trees."
+      "displayName": "Max Merkle Tree Age",
+      "description": "Maximum merkle tree age in seconds (e.g. 600s).",
+      "comment": "If a stream doesn't provides enough values to build an entire merkle tree with the given depth in the given time-period it will be splitted into smaller merkle trees."
     },
     {
       "@type": "Property",
       "name": "SubmissionInterval",
-      "schema": "duration",
+      "schema": "double",
       "writable": true,
       "displayName": "Submission Interval",
-      "description": "Timeout for a single merkle-tree for proofs.",
-      "comment": "If a stream doesn't provides enought values to build an entire merkle tree with the given depth in the given period it will be splitted into smaller merkle-trees."
+      "description": "The estimated data submission interval/frequency of the stream in Hz (e.g. 1.2Hz)."
     },
     {
       "@type": "Telemetry",

--- a/DTDL/base_stream.json
+++ b/DTDL/base_stream.json
@@ -51,7 +51,7 @@
       "schema": "integer",
       "writable": true,
       "displayName": "Max Merkle Tree Age",
-      "description": "Maximum merkle tree age in seconds (e.g. 600s).",
+      "description": "Maximum merkle tree age in seconds (e.g. 600).",
       "comment": "If a stream doesn't provides enough values to build an entire merkle tree with the given depth in the given time-period it will be splitted into smaller merkle trees."
     },
     {
@@ -60,7 +60,7 @@
       "schema": "double",
       "writable": true,
       "displayName": "Submission Interval",
-      "description": "The estimated data submission interval/frequency of the stream in Hz (e.g. 1.2Hz)."
+      "description": "The estimated data submission interval/frequency of the stream in Hz (e.g. 1.2)."
     },
     {
       "@type": "Telemetry",

--- a/DTDL/data_api_value_sink.json
+++ b/DTDL/data_api_value_sink.json
@@ -59,7 +59,7 @@
             "schema": "integer",
             "writable": true,
             "displayName": "Retry interval",
-            "description": "Delay interval (in seconds) for the first retry of call to Data-API on error (e.g. 1s)."
+            "description": "Delay interval (in seconds) for the first retry of call to Data-API on error (e.g. 1)."
         },
         {
             "@type": "Property",
@@ -67,7 +67,7 @@
             "schema": "integer",
             "writable": true,
             "displayName": "Max retry interval",
-            "description": "Maximum interval (in seconds) for delays of calls at Data-API on error (e.g. 30s)"
+            "description": "Maximum interval (in seconds) for delays of calls at Data-API on error (e.g. 30)"
         }
     ]
 }

--- a/DTDL/data_api_value_sink.json
+++ b/DTDL/data_api_value_sink.json
@@ -10,24 +10,24 @@
             "name": "BaseUrl",
             "schema": "string",
             "writable": true,
-            "displayName": "API Url",
-            "description": ""
+            "displayName": "Data-API Url",
+            "description": "URL of the Data-API (e.g. https://data-api.your-node-name.dataspace-node.com)"
         },
         {
             "@type": "Property",
             "name": "AuthUrl",
             "schema": "string",
             "writable": true,
-            "displayName": "Identity server URL",
-            "description": ""
+            "displayName": "Auth Server Token URL",
+            "description": "URL of the Token API at the Auth Server (e.g. https://auth.your-hub-name.dataspace-hub.com/auth/realms/your-node-name/protocol/openid-connect/token)"
         },
         {
             "@type": "Property",
             "name": "AuthScope",
             "schema": "string",
             "writable": true,
-            "displayName": "Identity server scope",
-            "description": ""
+            "displayName": "OAuth scope",
+            "description": "OAuth scope (e.g. \"profile email data-api node-id\")"
         },
         {
             "@type": "Property",
@@ -35,7 +35,7 @@
             "schema": "string",
             "writable": true,
             "displayName": "Client id for authentication",
-            "description": ""
+            "description": "Client Id used for authenticaiton (e.g. \"data-api\")"
         },
         {
             "@type": "Property",
@@ -51,7 +51,7 @@
             "schema": "integer",
             "writable": true,
             "displayName": "Max retries",
-            "description": "Number of maximum retries for calls at Data-API"
+            "description": "Number of maximum retries for calls at Data-API (e.g. 1024)."
         },
         {
             "@type": "Property",
@@ -59,7 +59,7 @@
             "schema": "integer",
             "writable": true,
             "displayName": "Retry interval",
-            "description": "Delay interval for the first retry of call to Data-API on error"
+            "description": "Delay interval (in seconds) for the first retry of call to Data-API on error (e.g. 1s)."
         },
         {
             "@type": "Property",
@@ -67,7 +67,7 @@
             "schema": "integer",
             "writable": true,
             "displayName": "Max retry interval",
-            "description": "Maximum interval for delays of calls at Data-API on error"
+            "description": "Maximum interval (in seconds) for delays of calls at Data-API on error (e.g. 30s)"
         }
     ]
 }

--- a/DTDL/edge.json
+++ b/DTDL/edge.json
@@ -10,16 +10,18 @@
       "name": "MaxMerkleTreeDepth",
       "schema": "integer",
       "writable": true,
-      "displayName": "Max merkle tree depth",
-      "description": "The Max merkle tree depth"
+      "displayName": "Max Merkle Tree Depth",
+      "description": "Maximum depth of the binary merkle-tree used for proof generation (e.g. 12). Value used as 2^MerkleTreeDepth.",
+      "comment": "Proofs allows to verify integrity and origin of the stream. A proof represents a binary-merkle-tree and 2^MerkleTreeDepth values are necessary to build a single proof."
     },
     {
       "@type": "Property",
       "name": "MaxMerkleTreeAge",
       "schema": "integer",
       "writable": true,
-      "displayName": "Max merkle tree age",
-      "description": "The Max merkle tree age"
+      "displayName": "Max Merkle Tree Age",
+      "description": "Maximum merkle tree age in seconds (e.g. 600s).",
+      "comment": "If a stream doesn't provides enough values to build an entire merkle tree with the given depth in the given time-period it will be splitted into smaller merkle trees."
     }
   ]
 }

--- a/DTDL/edge.json
+++ b/DTDL/edge.json
@@ -20,7 +20,7 @@
       "schema": "integer",
       "writable": true,
       "displayName": "Max Merkle Tree Age",
-      "description": "Maximum merkle tree age in seconds (e.g. 600s).",
+      "description": "Maximum merkle tree age in seconds (e.g. 600).",
       "comment": "If a stream doesn't provides enough values to build an entire merkle tree with the given depth in the given time-period it will be splitted into smaller merkle trees."
     }
   ]

--- a/DTDL/iot_hub_sink.json
+++ b/DTDL/iot_hub_sink.json
@@ -11,7 +11,7 @@
             "schema": "string",
             "writable": true,
             "displayName": "IoT Hub Connection string",
-            "description": "The connection string for the IoT Hub."
+            "description": "The connection string for the IoT Hub (e.g. \"HostName=<iot-hub-name>.azure-devices.net;DeviceId=<device-id>;SharedAccessKey=<key>\")."
         }
     ]
 }

--- a/DTDL/opcua_source.json
+++ b/DTDL/opcua_source.json
@@ -19,7 +19,7 @@
       "schema": "integer",
       "writable": true,
       "displayName": "OPC UA publishing interval",
-      "description": "The OPC UA publishing interval in milliseconds (e.g. 100ms)."
+      "description": "The OPC UA publishing interval in milliseconds (e.g. 100)."
     },
     {
       "@type": "Relationship",

--- a/DTDL/opcua_source.json
+++ b/DTDL/opcua_source.json
@@ -3,23 +3,23 @@
   "@id": "dtmi:io:tributech:source:opcua;1",
   "@type": "Interface",
   "extends": "dtmi:io:tributech:source:base;1",
-  "displayName": "OPCUA Source",
+  "displayName": "OPC UA Source",
   "contents": [
     {
       "@type": "Property",
       "name": "ConnectionString",
       "schema": "string",
       "writable": true,
-      "displayName": "OPCUA Connection string",
-      "description": "The connection string for the opcua value source"
+      "displayName": "OPC UA Connection string",
+      "description": "The connection string for the OPC UA value source (e.g. \"opc.tcp://opcua-server:4840\")"
     },
     {
       "@type": "Property",
       "name": "PublishingInterval",
       "schema": "integer",
       "writable": true,
-      "displayName": "OPCUA publishing interval",
-      "description": "The opcua publishing interval"
+      "displayName": "OPC UA publishing interval",
+      "description": "The OPC UA publishing interval in milliseconds (e.g. 100ms)."
     },
     {
       "@type": "Relationship",
@@ -28,7 +28,7 @@
       "maxMultiplicity": 10,
       "target": "dtmi:io:tributech:stream:opcua;1",
       "displayName": "Streams",
-      "description": "Contains all opcua streams the given source."
+      "description": "Contains all OPC UA streams the given source."
     }
   ]
 }

--- a/DTDL/opcua_stream.json
+++ b/DTDL/opcua_stream.json
@@ -2,7 +2,7 @@
     "@context": "dtmi:dtdl:context;2",
     "@id": "dtmi:io:tributech:stream:opcua;1",
     "@type": "Interface",
-    "displayName": "OPCUA Stream",
+    "displayName": "OPC UA Stream",
     "extends": "dtmi:io:tributech:stream:base;1",
     "contents": [
         {
@@ -11,7 +11,7 @@
             "schema": "string",
             "writable": true,
             "displayName": "Identifier",
-            "description": "The identifier for the opcua value source (eg. \"ns=1;i=0\")"
+            "description": "The identifier for the OPC UA value source (eg. \"ns=1;i=0\")"
         }
     ]
 }

--- a/DTDL/proof_sink.json
+++ b/DTDL/proof_sink.json
@@ -10,8 +10,8 @@
             "name": "BaseUrl",
             "schema": "string",
             "writable": true,
-            "displayName": "Data-API Url",
-            "description": "URL of the Data-API (e.g. https://data-api.your-node-name.dataspace-node.com)"
+            "displayName": "Trust-API Url",
+            "description": "URL of the Trust-API (e.g. https://trust-api.your-node-name.dataspace-node.com)"
         },
         {
             "@type": "Property",
@@ -27,7 +27,7 @@
             "schema": "string",
             "writable": true,
             "displayName": "OAuth scope",
-            "description": "OAuth scope (e.g. \"profile email data-api node-id\")"
+            "description": "OAuth scope (e.g. \"profile email trust-api data-api node-id\")"
         },
         {
             "@type": "Property",
@@ -35,7 +35,7 @@
             "schema": "string",
             "writable": true,
             "displayName": "Client id for authentication",
-            "description": "Client Id used for authenticaiton (e.g. \"data-api\")"
+            "description": "Client Id used for authenticaiton (e.g. \"trust-api\")"
         },
         {
             "@type": "Property",
@@ -59,7 +59,7 @@
             "schema": "integer",
             "writable": true,
             "displayName": "Max retry interval",
-            "description": "Maximum interval (in seconds) for delays of calls at Trust-API on error (e.g. 30s)"
+            "description": "Maximum interval (in seconds) for delays of calls at Trust-API on error (e.g. 30)"
         }
     ]
 }

--- a/DTDL/proof_sink.json
+++ b/DTDL/proof_sink.json
@@ -10,24 +10,24 @@
             "name": "BaseUrl",
             "schema": "string",
             "writable": true,
-            "displayName": "API Url",
-            "description": ""
+            "displayName": "Data-API Url",
+            "description": "URL of the Data-API (e.g. https://data-api.your-node-name.dataspace-node.com)"
         },
         {
             "@type": "Property",
             "name": "AuthUrl",
             "schema": "string",
             "writable": true,
-            "displayName": "Identity server URL",
-            "description": ""
+            "displayName": "Auth Server Token URL",
+            "description": "URL of the Token API at the Auth Server (e.g. https://auth.your-hub-name.dataspace-hub.com/auth/realms/your-node-name/protocol/openid-connect/token)"
         },
         {
             "@type": "Property",
             "name": "AuthScope",
             "schema": "string",
             "writable": true,
-            "displayName": "Identity server scope",
-            "description": ""
+            "displayName": "OAuth scope",
+            "description": "OAuth scope (e.g. \"profile email data-api node-id\")"
         },
         {
             "@type": "Property",
@@ -35,7 +35,7 @@
             "schema": "string",
             "writable": true,
             "displayName": "Client id for authentication",
-            "description": ""
+            "description": "Client Id used for authenticaiton (e.g. \"data-api\")"
         },
         {
             "@type": "Property",
@@ -47,34 +47,11 @@
         },
         {
             "@type": "Property",
-            "name": "BrokerType",
-            "schema": {
-                "@type": "Enum",
-                "valueSchema": "string",
-                "enumValues": [
-                    {
-                        "name": "MQTT",
-                        "displayName": "Mqtt",
-                        "enumValue": "MQTT"
-                    },
-                    {
-                        "name": "AzureEdgeRuntime",
-                        "displayName": "AzureEdgeRuntime",
-                        "enumValue": "AzureEdgeRuntime"
-                    }
-                ]
-            },
-            "writable": false,
-            "displayName": "Broker type",
-            "description": ""
-        },
-        {
-            "@type": "Property",
             "name": "MaxRetries",
             "schema": "integer",
             "writable": true,
             "displayName": "Max retries",
-            "description": "Number of maximum retries for calls at Trust-API"
+            "description": "Number of maximum retries for calls at Trust-API (e.g. 1024)."
         },
         {
             "@type": "Property",
@@ -82,7 +59,7 @@
             "schema": "integer",
             "writable": true,
             "displayName": "Max retry interval",
-            "description": "Maximum interval for delays of calls at Trust-API on error"
+            "description": "Maximum interval (in seconds) for delays of calls at Trust-API on error (e.g. 30s)"
         }
     ]
 }

--- a/DTDL/rabbitmq_source.json
+++ b/DTDL/rabbitmq_source.json
@@ -11,7 +11,7 @@
             "schema": "string",
             "writable": false,
             "displayName": "RabbitMQ Connection string",
-            "description": "The connection string for the RabbitMQ value source"
+            "description": "The connection string for the RabbitMQ value source (e.g. \"amqp://user:pass@host:10000/vhost\")."
         },
         {
             "@type": "Property",
@@ -19,7 +19,7 @@
             "schema": "integer",
             "writable": false,
             "displayName": "Max batch size",
-            "description": "The maximum number of values to send as batch in one message to the EdgeAgent."
+            "description": "The maximum number of values to send as batch in one message to the EdgeAgent. e.g. 1024"
         },
         {
             "@type": "Property",
@@ -27,7 +27,7 @@
             "schema": "integer",
             "writable": false,
             "displayName": "Flush interval",
-            "description": "The interval in which the values should be flushed from the buffer and send to the Data-API. Regardless if the MaxBatchSize was reached."
+            "description": "The interval (in seconds) in which the values should be flushed from the buffer and send to the Data-API. Regardless if the MaxBatchSize was reached. e.g. 1s"
         },
         {
             "@type": "Relationship",

--- a/DTDL/rabbitmq_source.json
+++ b/DTDL/rabbitmq_source.json
@@ -19,7 +19,7 @@
             "schema": "integer",
             "writable": false,
             "displayName": "Max batch size",
-            "description": "The maximum number of values to send as batch in one message to the EdgeAgent. e.g. 1024"
+            "description": "The maximum number of values to send as batch in one message to the EdgeAgent. (e.g. 1024)"
         },
         {
             "@type": "Property",
@@ -27,7 +27,7 @@
             "schema": "integer",
             "writable": false,
             "displayName": "Flush interval",
-            "description": "The interval (in seconds) in which the values should be flushed from the buffer and send to the Data-API. Regardless if the MaxBatchSize was reached. e.g. 1s"
+            "description": "The interval (in seconds) in which the values should be flushed from the buffer and send to the Data-API. Regardless if the MaxBatchSize was reached. (e.g. 1)"
         },
         {
             "@type": "Relationship",

--- a/DTDL/rabbitmq_stream.json
+++ b/DTDL/rabbitmq_stream.json
@@ -11,7 +11,7 @@
             "schema": "string",
             "writable": false,
             "displayName": "Queue name",
-            "description": "The RabbitMQ name"
+            "description": "The RabbitMQ queue name"
         }
     ]
 }

--- a/DTDL/replay_value_source.json
+++ b/DTDL/replay_value_source.json
@@ -20,7 +20,7 @@
             "schema": "string",
             "writable": true,
             "displayName": "File Name",
-            "description": "The name of the CSV file to use."
+            "description": "The name of the CSV file to use (e.g. \"Data/demo_data.csv\")."
         },
         {
             "@type": "Property",
@@ -28,7 +28,7 @@
             "schema": "double",
             "writable": true,
             "displayName": "Frequency",
-            "description": "The interval to use for replaying values line by line in ms."
+            "description": "The interval (in milliseconds) to use for replaying values line by line in (e.g. 100ms)"
         },
         {
             "@type": "Property",

--- a/DTDL/replay_value_source.json
+++ b/DTDL/replay_value_source.json
@@ -28,7 +28,7 @@
             "schema": "double",
             "writable": true,
             "displayName": "Frequency",
-            "description": "The interval (in milliseconds) to use for replaying values line by line in (e.g. 100ms)"
+            "description": "The interval (in milliseconds) to use for replaying values line by line in (e.g. 100)"
         },
         {
             "@type": "Property",

--- a/DTDL/simulated_value_source.json
+++ b/DTDL/simulated_value_source.json
@@ -19,7 +19,7 @@
             "schema": "integer",
             "writable": true,
             "displayName": "Flush interval",
-            "description": "The interval (in seconds) in which the values should be flushed from the buffer and send to the Data-API. Regardless if the MaxBatchSize was reached. e.g. 1s"
+            "description": "The interval (in seconds) in which the values should be flushed from the buffer and send to the Data-API. Regardless if the MaxBatchSize was reached. (e.g. 1)"
         },
         {
             "@type": "Relationship",

--- a/DTDL/simulated_value_source.json
+++ b/DTDL/simulated_value_source.json
@@ -11,7 +11,7 @@
             "schema": "integer",
             "writable": true,
             "displayName": "Max batch size",
-            "description": "The maximum number of values to send as batch in one message to the EdgeAgent."
+            "description": "The maximum number of values to send as batch in one message to the EdgeAgent (e.g. 1024)"
         },
         {
             "@type": "Property",
@@ -19,7 +19,7 @@
             "schema": "integer",
             "writable": true,
             "displayName": "Flush interval",
-            "description": "The interval in which the values should be flushed from the buffer and send to the Data-API. Regardless if the MaxBatchSize was reached."
+            "description": "The interval (in seconds) in which the values should be flushed from the buffer and send to the Data-API. Regardless if the MaxBatchSize was reached. e.g. 1s"
         },
         {
             "@type": "Relationship",

--- a/DTDL/simulated_value_stream.json
+++ b/DTDL/simulated_value_stream.json
@@ -55,7 +55,7 @@
             "schema": "double",
             "writable": true,
             "displayName": "Frequency",
-            "description": "Data Frequency in Hz (1/s) (e.g 1.0Hz)"
+            "description": "Data Frequency in Hz (1/s) (e.g 1.0)"
         }
     ]
 }

--- a/DTDL/simulated_value_stream.json
+++ b/DTDL/simulated_value_stream.json
@@ -36,18 +36,18 @@
         {
             "@type": "Property",
             "name": "MinValue",
-            "schema": "integer",
+            "schema": "double",
             "writable": true,
             "displayName": "Min value",
-            "description": "Minimum for generated values."
+            "description": "Minimum for generated values (e.g. -1.2 for double, -5 for int or 8 for binary)."
         },
         {
             "@type": "Property",
             "name": "MaxValue",
-            "schema": "integer",
+            "schema": "double",
             "writable": true,
             "displayName": "Max value",
-            "description": "Maximum for generated values."
+            "description": "Maximum for generated values (e.g. 3.25 for double, 1204 for int or 512 for binary)."
         },
         {
             "@type": "Property",
@@ -55,7 +55,7 @@
             "schema": "double",
             "writable": true,
             "displayName": "Frequency",
-            "description": "Data Frequency in Hz (1/s) "
+            "description": "Data Frequency in Hz (1/s) (e.g 1.0Hz)"
         }
     ]
 }

--- a/DTDL/ssm.json
+++ b/DTDL/ssm.json
@@ -11,7 +11,7 @@
       "schema": "string",
       "writable": true,
       "displayName": "Software Version",
-      "description": "Represents the current running software version."
+      "description": "Represents the current running software version (e.g. v1.0.0)."
     },
     {
       "@type": "Property",
@@ -19,7 +19,7 @@
       "schema": "string",
       "writable": true,
       "displayName": "Hardware Version",
-      "description": "Represents the current running hardware version."
+      "description": "Represents the current running hardware version (e.g. v1.0.0)."
     },
     {
       "@type": "Property",

--- a/DTDL/ssm_stream_deviceinterfaceprotocol.json
+++ b/DTDL/ssm_stream_deviceinterfaceprotocol.json
@@ -8,10 +8,10 @@
     {
       "@type": "Property",
       "name": "MinInterval",
-      "schema": "duration",
+      "schema": "integer",
       "writable": true,
       "displayName": "Minimum Time Interval",
-      "description": "Specifies the minimal time-interval of values which can be provided for this stream.",
+      "description": "Specifies the minimal time-interval (in milliseconds) of values which can be provided for this stream.",
       "comment": "Data for the stream provided in less than the specified minimal time-interval gets discarded."
     }
   ]


### PR DESCRIPTION
* change to numeric schema type for time intervals (instead of duration)
(MerkleTreeTimeout, MinInterval -> int; SubmissionInterval -> double)
* improve doc (duration units, sampel values)
* remove unused broker type at proof sink